### PR TITLE
Check for download class inside conditional

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidyFIA
 Title: Assemble Forest Inventory and Analysis (FIA) Data for Analysis
-Version: 0.12
+Version: 0.13
 Authors@R: c(
     person("Rodman", "Henry", , email = "henry@silviaterra.com", role = c("aut", "cre")),
     person("Clough", "Brian", , email = "brian@silviaterra.com", role = "aut"),

--- a/R/download_FIADB.R
+++ b/R/download_FIADB.R
@@ -63,14 +63,15 @@ download_and_unzip <- function(url, file_dir) {
 
   if (!file.exists(zip_file)) {
     downloaded <- try(utils::download.file(url, destfile = zip_file))
-  }
-
-  if ("try-error" %in% class(downloaded)) {
-    stop(
-      glue::glue(
-        "{url} is not available to download at the moment"
+  
+    if ("try-error" %in% class(downloaded)) {
+      stop(
+        glue::glue(
+          "{url} is not available to download at the moment"
+        )
       )
-    )
+    }
+  
   }
 
   utils::unzip(

--- a/R/tidy_FIA.R
+++ b/R/tidy_FIA.R
@@ -114,6 +114,10 @@ tidy_fia <- function(states = NULL, aoi = NULL, postgis = TRUE,
 
     # spatialize plots table
     tables[["plot"]] <- tables[["plot"]] %>%
+      dplyr::filter(
+        !is.na(lon),
+        !is.na(lat)
+      ) %>%
       sf::st_as_sf(
         coords = c("lon", "lat"),
         crs = 4326,


### PR DESCRIPTION
This pull request fixes a bug that occurs when downloading from the csv DB. The bug occurs when a download has already happened and so the target file already exists, thus skipping the the creation of object `downloaded`, which is then evaluated for `try-error` and fails.

The fix simply moves the check inside of the conditional so is skipped if the target already exists.

[Edit:]

Also filter out plots where `lat` or `lon` are `NA` when downloading from the datamart.