### PR TITLE
eliminate quotes from in_schema call

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidyFIA
 Title: Assemble Forest Inventory and Analysis (FIA) Data for Analysis
-Version: 0.13
+Version: 0.14
 Authors@R: c(
     person("Rodman", "Henry", , email = "henry@silviaterra.com", role = c("aut", "cre")),
     person("Clough", "Brian", , email = "brian@silviaterra.com", role = "aut"),

--- a/R/query_FIADB.R
+++ b/R/query_FIADB.R
@@ -42,7 +42,7 @@ query_table <- function(table_name, plt_cns, con) {
   table_call <- as.character(glue::glue("fs_fiadb.{table_name}"))
   tab <- dplyr::tbl(
     con,
-    dbplyr::in_schema("fiadb", table_call)
+    dbplyr::in_schema(dbplyr::sql("fiadb"), dbplyr::sql(table_call))
   )
 
   plt_cn_field <- dplyr::case_when(

--- a/R/tidy_FIA.R
+++ b/R/tidy_FIA.R
@@ -115,8 +115,8 @@ tidy_fia <- function(states = NULL, aoi = NULL, postgis = TRUE,
     # spatialize plots table
     tables[["plot"]] <- tables[["plot"]] %>%
       dplyr::filter(
-        !is.na(lon),
-        !is.na(lat)
+        !is.na(.data[["lon"]]),
+        !is.na(.data[["lat"]])
       ) %>%
       sf::st_as_sf(
         coords = c("lon", "lat"),

--- a/tests/testthat/test-tidy_FIA.R
+++ b/tests/testthat/test-tidy_FIA.R
@@ -4,9 +4,10 @@ test_that("tidy_fia produces expected output when postgis = TRUE", {
     tidy_fia(aoi = NULL, states = NULL, table_names = c("plot", "tree"))
   )
 
-  aoi <- spData::us_states %>%
-    dplyr::filter(NAME == "Minnesota") %>%
-    sf::st_sample(size = 1, type = "random") %>%
+  xy <- sf::st_point(c(-92.5267, 46.6887))
+  pt <- sf::st_sfc(xy, crs = 4326)
+
+  aoi <- pt %>%
     sf::st_sf() %>%
     sf::st_transform(2163) %>%
     sf::st_buffer(20000)


### PR DESCRIPTION
I am not sure if this a `dplyr` or `dbplyr`-side change but `query_table` was breaking. I confirmed that tests failed before this change, pass after the change.

resolves #9

